### PR TITLE
feat: support V2 endpoints

### DIFF
--- a/src/v2/catalog/index.ts
+++ b/src/v2/catalog/index.ts
@@ -1,0 +1,17 @@
+import { FetchDataFn } from '../../client';
+// import getSomething from './getSomething';
+
+// TODO v1.3.0
+export interface ICatalogV2 {
+  // getSomething: ReturnType<typeof getSomething>;
+}
+
+class CatalogV2 implements ICatalogV2 {
+  //   getSomething: ReturnType<typeof getSomething>;
+
+  constructor(fetchData: FetchDataFn, shopId: string) {
+    // this.getSomething = getSomething(fetchData);
+  }
+}
+
+export default CatalogV2;

--- a/src/v2/types.ts
+++ b/src/v2/types.ts
@@ -1,0 +1,5 @@
+// Catalog
+// TODO v1.3.0
+export interface ReplaceMe {
+  example: any;
+}

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -65,3 +65,7 @@ describe('Catalog', () => {
     assertAxiosCall('get', '/v1/catalog/print_providers.json');
   });
 });
+
+describe('Catalog V2', () => {
+  // TODO v1.3.0
+});


### PR DESCRIPTION
### Checklist

- [ ] Implement V2 endpoints
- [ ] Unit tests
- [ ] Add V2 endpoint types
- [ ] Update documentation
- [ ] Create `1.3.0` minor bump (+CHANGELOG)
- [ ] npm publish
- [ ] Create github release
- [ ] Comment on issue #30 and close

### Changes

```diff
    import Catalog, { ICatalog } from './v1/catalog';
+   import CatalogV2, { ICatalogV2 } from './v2/catalog';

    class Printify {
        // ...
        catalog: ICatalog;
+       catalog!: ICatalog | ICatalogV2;
        
        constructor(config: PrintifyConfig) {
            // ...
-           this.catalog = new Catalog(this.fetchData.bind(this), this.shopId);
+           this.catalog = config.apiVersion === 'v2' ? new CatalogV2(this.fetchData.bind(this), this.shopId) : new Catalog(this.fetchData.bind(this), this.shopId);
            // ...
        }
    }
```

### Example Usage (draft)

```js
// v1 endpoints (existing)
import Printify from 'printify-sdk-js';
import type { Blueprint } from 'printify-sdk-js';

const printify = new Printify({
  accessToken: '{{API_KEY}}',
  apiVersion: 'v1', // default
});

const blueprints: Blueprint[] = await printify.catalog.listBlueprints(); // GET /v1/catalog/blueprints.json
```

```js
// v2 endpoints (new)
import Printify from 'printify-sdk-js'; // >= v1.3.0
import type { GetShippingListInfoResponse } from 'printify-sdk-js';

const printify = new Printify({
  accessToken: '{{API_KEY}}',
  apiVersion: 'v2',
});

const res: GetShippingListInfoResponse = await printify.catalog.getShippingListInfo(); // GET /v2/catalog/blueprints/{blueprint_id}/print_providers/{print_provider_id}/shipping.json
```